### PR TITLE
Get GeoIP info in standalone mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ You can either import everything as an Eclipse project, adjust the Build path an
 
 	tar -xf standalone.tar.gz 
 	cd standalone/
+	ln -s ../geoip geoip
 	java -Djava.library.path=./library -jar trace.jar
 
 


### PR DESCRIPTION
When running the standalone modes, I didn't get the globe links visualization, and got the following errors:

```
java.io.FileNotFoundException: ./geoip/GeoLiteCity.dat (No such file or directory)
```

Adding a symbolic link to the parent `geoip` folder fixes the problem!
