### PR TITLE
Fix Links to Blue Marble and  GeoIP Database

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can either import everything as an Eclipse project, adjust the Build path an
 
 # Maps
 
-The textures are taken from the [http://visibleearth.nasa.gov/view_set.php?categoryId=2363&p=1](NASA's Blue Marble project). 
+The textures are taken from the [NASA's Blue Marble project](https://visibleearth.nasa.gov/view.php?id=57723). 
 
 
 # GeoIP
@@ -50,7 +50,7 @@ The GeoIP lookup is done using a GeoIP database:
 	acknowledgment: "This product includes GeoLite data created by MaxMind, 
 	available from http://www.maxmind.com/."
 
-You can download the current GeoIP database [http://geolite.maxmind.com/download/geoip/database/](here).
+You can download the current GeoIP database [here](http://geolite.maxmind.com/download/geoip/database/).
 
 
 # Contributors


### PR DESCRIPTION
Fix markdown for links to Blue Marble and  GeoIP Database.

Update Blue Marble link; old one no longer works.